### PR TITLE
🔀 Redone blockState Map

### DIFF
--- a/src/main/java/tech/Astolfo/AstolfoCaffeine/main/util/minecraft/Block.java
+++ b/src/main/java/tech/Astolfo/AstolfoCaffeine/main/util/minecraft/Block.java
@@ -16,6 +16,10 @@ public class Block {
 
     public enum Material {
         STONE,
+        EMERALD_ORE,
+        DIAMOND_ORE,
+        GOLD_ORE,
+        IRON_ORE,
         WOOD,
         DIRT,
         ASTOLFO
@@ -23,7 +27,6 @@ public class Block {
 
     //private final String emote_template;
     private final Material mat;
-    private final Short data;
     public State state;
     private int hits;
     public int stage;
@@ -63,108 +66,101 @@ public class Block {
 
     */
 
-    public static HashMap<Material, HashMap<Short, List<String>>> blockState = new HashMap<>() {{
-        put(
-                Material.STONE,
-                new HashMap<>() {{
-                    put(
-                            // Emerald Ore
-                            (short) 0,
-                            Arrays.asList(
-                                    "738014582555279460", // 1
-                                    "738014591988138045", // 2
-                                    "738014594911698996", // 3
-                                    "738014598862733422", // 4
-                                    "738015059070156830", // 5
-                                    "738015060949205083", // 6
-                                            "738015063960584222", // 7
-                                            "738015063025123360", // 8
-                                            "738015061922021437", // 9
-                                            "738015062274342939"  // 10
-                                    )
-                            );
-
-                            put(
-                                    // Diamond Ore
-                                    (short) 1,
-                                    Arrays.asList(
-                                            "761581882109853706", // 1
-                                            "761581882206715934", // 2
-                                            "761581882407911454", // 3
-                                            "761581882818297856", // 4
-                                            "761581882689060865", // 5
-                                            "761581882718289941", // 6
-                                            "761581883111899166", // 7
-                                            "761581883196440596", // 8
-                                            "761581882756038707", // 9
-                                            "761581883301167134"  // 10
-                                    )
-                            );
-
-                            put(
-                                    // Gold Ore
-                                    (short) 2,
-                                    Arrays.asList(
-                                            "761585001925967872", // 1
-                                            "761585001862004776", // 2
-                                            "761585002067918908", // 3
-                                            "761585002332815360", // 4
-                                            "761585002307649561", // 5
-                                            "761585002281697293", // 6
-                                            "761585002290217041", // 7
-                                            "761585002361651250", // 8
-                                            "761585002362175488", // 9
-                                            "761585002374496266"  // 10
-                                    )
-                            );
-
-                            put(
-                                    // Iron Ore
-                                    (short) 3,
-                                    Arrays.asList(
-                                            "761587111388250152", // 1
-                                            "761586946241462353", // 2
-                                            "761586946287206440", // 3
-                                            "761586946241724436", // 4
-                                            "761586945821376523", // 5
-                                            "761586946170159125", // 6
-                                            "761586946244870154", // 7
-                                            "761586946186543165", // 8
-                                            "761586945956118600", // 9
-                                            "761586946308308992" // 10
-                                    )
-                            );
-                }}
-        );
+    public static HashMap<Material, List<String>> blockState = new HashMap<>() {
+        {
 
 
-        put(
-                Material.ASTOLFO,
-                new HashMap<>() {{
-                    put(
-                            (short) 0,
-                            Arrays.asList(
-                                    "761598965253799946", // 1
-                                    "761598360846729236", // 2
-                                    "761598361156583424", // 3
-                                    "761598361505628200", // 4
-                                    "761598361606160455", // 5
-                                    "761598361374687302", // 6
-                                    "761598361274023956", // 7
-                                    "761598361013977099", // 8
-                                    "761598360469241876", // 9
-                                    "761598360360190012"  // 10
-                            )
-                    );
-                }}
-        );
-    }};
+            // Ores
+
+            put(
+                    Material.EMERALD_ORE,
+                    Arrays.asList(
+                            "738014582555279460", // 1
+                            "738014591988138045", // 2
+                            "738014594911698996", // 3
+                            "738014598862733422", // 4
+                            "738015059070156830", // 5
+                            "738015060949205083", // 6
+                            "738015063960584222", // 7
+                            "738015063025123360", // 8
+                            "738015061922021437", // 9
+                            "738015062274342939"  // 10
+                    )
+            );
+
+            put(
+                    Material.DIAMOND_ORE,
+                    Arrays.asList(
+                            "761581882109853706", // 1
+                            "761581882206715934", // 2
+                            "761581882407911454", // 3
+                            "761581882818297856", // 4
+                            "761581882689060865", // 5
+                            "761581882718289941", // 6
+                            "761581883111899166", // 7
+                            "761581883196440596", // 8
+                            "761581882756038707", // 9
+                            "761581883301167134"  // 10
+                    )
+            );
+
+            put(
+                    Material.GOLD_ORE,
+                    Arrays.asList(
+                            "761585001925967872", // 1
+                            "761585001862004776", // 2
+                            "761585002067918908", // 3
+                            "761585002332815360", // 4
+                            "761585002307649561", // 5
+                            "761585002281697293", // 6
+                            "761585002290217041", // 7
+                            "761585002361651250", // 8
+                            "761585002362175488", // 9
+                            "761585002374496266"  // 10
+                    )
+            );
+
+            put(
+                    Material.IRON_ORE,
+                    Arrays.asList(
+                            "761587111388250152", // 1
+                            "761586946241462353", // 2
+                            "761586946287206440", // 3
+                            "761586946241724436", // 4
+                            "761586945821376523", // 5
+                            "761586946170159125", // 6
+                            "761586946244870154", // 7
+                            "761586946186543165", // 8
+                            "761586945956118600", // 9
+                            "761586946308308992" // 10
+                    )
+            );
 
 
-    public Block(Material _material, Short _data, int _num_stages, int _hits_per_stage, int _value, int _max_time) {
+            // Miscellaneous
+
+            put(
+                    Material.ASTOLFO,
+                    Arrays.asList(
+                            "761598965253799946", // 1
+                            "761598360846729236", // 2
+                            "761598361156583424", // 3
+                            "761598361505628200", // 4
+                            "761598361606160455", // 5
+                            "761598361374687302", // 6
+                            "761598361274023956", // 7
+                            "761598361013977099", // 8
+                            "761598360469241876", // 9
+                            "761598360360190012"  // 10
+                    )
+            );
+        }
+    };
+
+
+    public Block(Material _material, int _num_stages, int _hits_per_stage, int _value, int _max_time) {
         //emote_template = _emote_template;
         mat = _material;
-        data = _data;
         num_stages = _num_stages;
         hits_per_stage = _hits_per_stage;
         value = _value;
@@ -204,7 +200,7 @@ public class Block {
 
     public String render() {
         //Emote emote = Objects.requireNonNull(jda.getGuildById(emote_server)).getEmotesByName(String.format(emote_template, stage), false).get(0);
-        Emote emote = Objects.requireNonNull(jda.getGuildById(emote_server)).getEmoteById(blockState.get(mat).get(data).get(stage));
+        Emote emote = Objects.requireNonNull(jda.getGuildById(emote_server)).getEmoteById(blockState.get(mat).get(stage));
         assert emote != null;
         return emote.getAsMention();
     }


### PR DESCRIPTION
Altered the blockState map to hold a list of emoji IDs instead of a HashMap with data IDs to associate with each emoji ID, essentially removed a layer from retrieving block state information. Additionally, new material types were added to the block constructor to allow for the changes to the blockState map.